### PR TITLE
refactor: cleanup dead code and consolidate duplicate setup() calls

### DIFF
--- a/lua/plugins/lsp/lsp-config.lua
+++ b/lua/plugins/lsp/lsp-config.lua
@@ -32,11 +32,7 @@ return {
 
 			vim.api.nvim_create_autocmd("LspAttach", {
 				callback = function(args)
-					local client = vim.lsp.get_client_by_id(args.data.client_id)
 					local bufnr = args.buf
-					if client and client.name == "ts_ls" then
-						client.server_capabilities.semanticTokensProvider = nil
-					end
 					local opts = { buffer = bufnr }
 					vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
 					vim.keymap.set("n", "<leader>ld", vim.lsp.buf.definition, opts)

--- a/lua/plugins/misc/ryoppippi-svelte_inspector.lua
+++ b/lua/plugins/misc/ryoppippi-svelte_inspector.lua
@@ -1,6 +1,8 @@
 return {
 	"ryoppippi/vim-svelte-inspector",
 	event = "VeryLazy",
+	-- flatten: open files from browser devtools in current Neovim instance
+	-- fileline: parse file:line:col format from inspector click and jump there
 	dependencies = {
 		"willothy/flatten.nvim",
 		"lewis6991/fileline.nvim",

--- a/lua/plugins/nvim-treesitter-textobjects.lua
+++ b/lua/plugins/nvim-treesitter-textobjects.lua
@@ -2,61 +2,6 @@ return {
 	"nvim-treesitter/nvim-treesitter-textobjects",
 	event = "VeryLazy",
 	dependencies = { "nvim-treesitter/nvim-treesitter" },
-	config = function()
-		require("nvim-treesitter").setup({
-			textobjects = {
-				select = {
-					enable = true,
-					lookahead = true,
-					keymaps = {
-						["af"] = { query = "@function.outer", desc = "outer function" },
-						["if"] = { query = "@function.inner", desc = "inner function" },
-						["ac"] = { query = "@class.outer", desc = "outer class" },
-						["ic"] = { query = "@class.inner", desc = "inner class" },
-						["ai"] = { query = "@conditional.outer", desc = "outer conditional" },
-						["ii"] = { query = "@conditional.inner", desc = "inner conditional" },
-						["al"] = { query = "@loop.outer", desc = "outer loop" },
-						["il"] = { query = "@loop.inner", desc = "inner loop" },
-						["aa"] = { query = "@parameter.outer", desc = "outer argument" },
-						["ia"] = { query = "@parameter.inner", desc = "inner argument" },
-						["ab"] = { query = "@block.outer", desc = "outer block" },
-						["ib"] = { query = "@block.inner", desc = "inner block" },
-					},
-				},
-
-				move = {
-					enable = true,
-					set_jumps = true,
-					goto_next_start = {
-						["]f"] = { query = "@function.outer", desc = "Next function start" },
-						["]c"] = { query = "@class.outer", desc = "Next class start" },
-						["]a"] = { query = "@parameter.inner", desc = "Next argument start" },
-					},
-					goto_next_end = {
-						["]F"] = { query = "@function.outer", desc = "Next function end" },
-						["]C"] = { query = "@class.outer", desc = "Next class end" },
-					},
-					goto_previous_start = {
-						["[f"] = { query = "@function.outer", desc = "Prev function start" },
-						["[c"] = { query = "@class.outer", desc = "Prev class start" },
-						["[a"] = { query = "@parameter.inner", desc = "Prev argument start" },
-					},
-					goto_previous_end = {
-						["[F"] = { query = "@function.outer", desc = "Prev function end" },
-						["[C"] = { query = "@class.outer", desc = "Prev class end" },
-					},
-				},
-
-				swap = {
-					enable = true,
-					swap_next = {
-						["<leader>sn"] = { query = "@parameter.inner", desc = "Swap next argument" },
-					},
-					swap_previous = {
-						["<leader>sp"] = { query = "@parameter.inner", desc = "Swap prev argument" },
-					},
-				},
-			},
-		})
-	end,
+	-- Config is merged into nvim-treesitter.lua's setup() call
+	-- to avoid the fragility of calling require("nvim-treesitter").setup() twice.
 }

--- a/lua/plugins/treesitter/nvim-treesitter.lua
+++ b/lua/plugins/treesitter/nvim-treesitter.lua
@@ -40,6 +40,59 @@ return {
 					node_decremental = "grm",
 				},
 			},
+
+			-- nvim-treesitter-textobjects: merged here to avoid duplicate setup()
+			textobjects = {
+				select = {
+					enable = true,
+					lookahead = true,
+					keymaps = {
+						["af"] = { query = "@function.outer", desc = "outer function" },
+						["if"] = { query = "@function.inner", desc = "inner function" },
+						["ac"] = { query = "@class.outer", desc = "outer class" },
+						["ic"] = { query = "@class.inner", desc = "inner class" },
+						["ai"] = { query = "@conditional.outer", desc = "outer conditional" },
+						["ii"] = { query = "@conditional.inner", desc = "inner conditional" },
+						["al"] = { query = "@loop.outer", desc = "outer loop" },
+						["il"] = { query = "@loop.inner", desc = "inner loop" },
+						["aa"] = { query = "@parameter.outer", desc = "outer argument" },
+						["ia"] = { query = "@parameter.inner", desc = "inner argument" },
+						["ab"] = { query = "@block.outer", desc = "outer block" },
+						["ib"] = { query = "@block.inner", desc = "inner block" },
+					},
+				},
+				move = {
+					enable = true,
+					set_jumps = true,
+					goto_next_start = {
+						["]f"] = { query = "@function.outer", desc = "Next function start" },
+						["]c"] = { query = "@class.outer", desc = "Next class start" },
+						["]a"] = { query = "@parameter.inner", desc = "Next argument start" },
+					},
+					goto_next_end = {
+						["]F"] = { query = "@function.outer", desc = "Next function end" },
+						["]C"] = { query = "@class.outer", desc = "Next class end" },
+					},
+					goto_previous_start = {
+						["[f"] = { query = "@function.outer", desc = "Prev function start" },
+						["[c"] = { query = "@class.outer", desc = "Prev class start" },
+						["[a"] = { query = "@parameter.inner", desc = "Prev argument start" },
+					},
+					goto_previous_end = {
+						["[F"] = { query = "@function.outer", desc = "Prev function end" },
+						["[C"] = { query = "@class.outer", desc = "Prev class end" },
+					},
+				},
+				swap = {
+					enable = true,
+					swap_next = {
+						["<leader>sn"] = { query = "@parameter.inner", desc = "Swap next argument" },
+					},
+					swap_previous = {
+						["<leader>sp"] = { query = "@parameter.inner", desc = "Swap prev argument" },
+					},
+				},
+			},
 		})
 	end,
 }


### PR DESCRIPTION
## Summary

Cleanup from code review: remove dead ts_ls check in lsp-config, consolidate duplicate nvim-treesitter setup() calls, add dependency comments.

## Changes

- Remove unused `client.name == "ts_ls"` check from lsp-config.lua (handled by typescript-tools)
- Merge nvim-treesitter-textobjects config into main nvim-treesitter setup() to avoid double setup() call
- Add comments explaining flatten.nvim/fileline.nvim dependency purpose in svelte-inspector

## Notes

- CI: nvim-lint (stylua + luacheck) confirmed passing
- Startup check will validate config changes