### PR TITLE
feat: use symlink for NazoVim config instead of copy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,16 +56,19 @@
               CONFIG_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/$APPNAME"
               DATA_DIR="''${XDG_DATA_HOME:-$HOME/.local/share}/$APPNAME"
               export NVIM_APPNAME="$APPNAME"
-              # 毎回 config を削除して再作成
-              echo "[nazozokc.nvim] Refreshing config at $CONFIG_DIR ..."
-              if [ -d "$CONFIG_DIR" ]; then
+              # symlink なら既存チェック不要、存在すれば上書き
+              if [ -L "$CONFIG_DIR" ]; then
+                rm "$CONFIG_DIR"
+              elif [ -d "$CONFIG_DIR" ]; then
                 rm -rf "$CONFIG_DIR"
               fi
-              mkdir -p "$CONFIG_DIR"
-              cp -r ${nvimConfig}/. "$CONFIG_DIR/"
-              chmod -R u+w "$CONFIG_DIR"
+              ln -s ${nvimConfig} "$CONFIG_DIR"
               # lazy.nvim のデータディレクトリを事前に作成
               mkdir -p "$DATA_DIR"
+              # 初回起動時に Nix store の lockfile を data dir にコピー
+              if [ ! -f "$DATA_DIR/lazy-lock.json" ] && [ -f "$CONFIG_DIR/lazy-lock.json" ]; then
+                cp "$CONFIG_DIR/lazy-lock.json" "$DATA_DIR/lazy-lock.json"
+              fi
               exec nvim "$@"
             '';
           };

--- a/init.lua
+++ b/init.lua
@@ -67,6 +67,7 @@ require("lazy").setup("plugins", {
 	defaults = {
 		lazy = true,
 	},
+	lockfile = vim.fn.stdpath("data") .. "/lazy-lock.json",
 	rocks = {
 		enabled = false,
 	},


### PR DESCRIPTION
## Summary

Use Nix store symlinks instead of copying config files to `.config/nvim-nazozokc`.

## Changes

- `init.lua`: Redirect lazy.nvim lockfile to data dir (`stdpath("data")`) so config dir stays read-only
- `flake.nix`: Replace `cp -r` with `ln -s` to Nix store derivation; copy lockfile to data dir on first run

## Notes

- Config dir (`~/.config/nvim-nazozokc`) is now a symlink to `/nix/store/...`, immutable
- All writable state (`lazy-lock.json`, plugins, caches) goes to `~/.local/share/nvim-nazozokc/`
- `devShell` retains copy behavior for development convenience